### PR TITLE
Allow stdout with --ascii

### DIFF
--- a/src/age/cli.py
+++ b/src/age/cli.py
@@ -57,7 +57,7 @@ def encrypt(
     if recipients is None:
         recipients = []
 
-    if outfile is sys.stdout.buffer and sys.stdout.isatty():
+    if outfile is sys.stdout.buffer and sys.stdout.isatty() and not ascii_armored:
         print("Refusing to encrypt to a TTY.", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
pyage doesn't allow output to a TTY because it may not be safe if it's binary, but with the `--ascii` switch added std should be fine.